### PR TITLE
Remove `Template:Cs1 wrapper` redirect

### DIFF
--- a/Template/Cs1 wrapper.mediawiki
+++ b/Template/Cs1 wrapper.mediawiki
@@ -1,3 +1,0 @@
-#REDIRECT [[Template:CS1 wrapper]]
-
-{{R from move}}

--- a/page-exchange.json
+++ b/page-exchange.json
@@ -970,11 +970,6 @@
                     "url": "https:\/\/raw.githubusercontent.com\/WikiTeq\/mediawiki-pages-CitationTool\/master\/Template%2FCite%20video%20game%23doc.mediawiki"
                 },
                 {
-                    "name": "Cs1 wrapper",
-                    "namespace": "NS_TEMPLATE",
-                    "url": "https:\/\/raw.githubusercontent.com\/WikiTeq\/mediawiki-pages-CitationTool\/master\/Template%2FCs1%20wrapper.mediawiki"
-                },
-                {
                     "name": "Intricate template",
                     "namespace": "NS_TEMPLATE",
                     "url": "https:\/\/raw.githubusercontent.com\/WikiTeq\/mediawiki-pages-CitationTool\/master\/Template%2FIntricate%20template.mediawiki"


### PR DESCRIPTION
Breaks Windows clones since there is also `Template:CS1 wrapper`, the lowercase redirects to the uppercase but isn't used in any of the other templates in this package so just delete it.

HI1-18